### PR TITLE
Add fr/it/en translations for the Thymio extension

### DIFF
--- a/src/extensions/scratch3_thymio/index.js
+++ b/src/extensions/scratch3_thymio/index.js
@@ -1085,7 +1085,7 @@ class Scratch3ThymioBlocks {
             blocks: [
                 {
                     opcode: 'setMotor',
-                    text: 'moteur [M] [N]',
+                    text: messages.blocks.setMotor,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         M: {
@@ -1101,12 +1101,12 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'stopMotors',
-                    text: 'stop moteurs',
+                    text: messages.blocks.stopMotors,
                     blockType: BlockType.COMMAND
                 },
                 {
                     opcode: 'move',
-                    text: 'avancer [N]',
+                    text: messages.blocks.move,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         N: {
@@ -1117,7 +1117,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'moveWithSpeed',
-                    text: 'avancer [N] avec vitesse [S]',
+                    text: messages.blocks.moveWithSpeed,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         N: {
@@ -1132,7 +1132,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'moveWithTime',
-                    text: 'avancer [N] en [S]s',
+                    text: messages.blocks.moveWithTime,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         N: {
@@ -1147,7 +1147,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'turn',
-                    text: 'tourner [N]',
+                    text: messages.blocks.turn,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         N: {
@@ -1158,7 +1158,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'turnWithSpeed',
-                    text: 'tourner [N] avec vitesse [S]',
+                    text: messages.blocks.turnWithSpeed,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         N: {
@@ -1173,7 +1173,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'turnWithTime',
-                    text: 'tourner [N] en [S]s',
+                    text: messages.blocks.turnWithTime,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         N: {
@@ -1188,7 +1188,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'arc',
-                    text: 'cercle rayon [R] angle [A]',
+                    text: messages.blocks.arc,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         R: {
@@ -1203,7 +1203,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'setOdomoter',
-                    text: 'odomètre [N] [O] [P]',
+                    text: messages.blocks.setOdomoter,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         N: {
@@ -1222,7 +1222,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'leds',
-                    text: 'leds RVB [L] [R] [G] [B]',
+                    text: messages.blocks.leds,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         L: {
@@ -1246,7 +1246,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'setLeds',
-                    text: 'leds fixer couleur [C] sur [L]',
+                    text: messages.blocks.setLeds,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         L: {
@@ -1262,7 +1262,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'changeLeds',
-                    text: 'leds augmenter couleur [C] sur [L]',
+                    text: messages.blocks.changeLeds,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         L: {
@@ -1278,12 +1278,12 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'clearLeds',
-                    text: 'éteindre leds',
+                    text: messages.blocks.clearLeds,
                     blockType: BlockType.COMMAND
                 },
                 {
                     opcode: 'nextDial',
-                    text: 'led cadran suivante [L]',
+                    text: messages.blocks.nextDial,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         L: {
@@ -1295,7 +1295,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'ledsCircle',
-                    text: 'leds cadran toutes [A] [B] [C] [D] [E] [F] [G] [H]',
+                    text: messages.blocks.ledsCircle,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         A: {
@@ -1334,7 +1334,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'ledsProxH',
-                    text: 'leds capteurs horiz. [A] [B] [C] [D] [E] [F] [G] [H]',
+                    text: messages.blocks.ledsProxH,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         A: {
@@ -1373,7 +1373,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'ledsProxV',
-                    text: 'leds capteurs dessous [A] [B]',
+                    text: messages.blocks.ledsProxV,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         A: {
@@ -1388,7 +1388,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'ledsButtons',
-                    text: 'leds boutons [A] [B] [C] [D]',
+                    text: messages.blocks.ledsButtons,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         A: {
@@ -1411,7 +1411,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'ledsTemperature',
-                    text: 'leds température [A] [B]',
+                    text: messages.blocks.ledsTemperature,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         A: {
@@ -1426,7 +1426,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'ledsRc',
-                    text: 'leds rc [A]',
+                    text: messages.blocks.ledsRc,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         A: {
@@ -1437,7 +1437,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'ledsSound',
-                    text: 'leds son [A]',
+                    text: messages.blocks.ledsSound,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         A: {
@@ -1448,7 +1448,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'soundSystem',
-                    text: 'jouer son système [S]',
+                    text: messages.blocks.soundSystem,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         S: {
@@ -1460,7 +1460,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'soundFreq',
-                    text: 'jouer note [N] pendant [S]s',
+                    text: messages.blocks.soundFreq,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         N: {
@@ -1475,7 +1475,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'soundPlaySd',
-                    text: 'jouer son SD [N]',
+                    text: messages.blocks.soundPlaySd,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         N: {
@@ -1486,7 +1486,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'soundRecord',
-                    text: 'enregistrer son [N]',
+                    text: messages.blocks.soundRecord,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         N: {
@@ -1497,7 +1497,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'soundReplay',
-                    text: 'rejouer son [N]',
+                    text: messages.blocks.soundReplay,
                     blockType: BlockType.COMMAND,
                     arguments: {
                         N: {
@@ -1508,7 +1508,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'whenButton',
-                    text: 'bouton [B]',
+                    text: messages.blocks.whenButton,
                     blockType: BlockType.HAT,
                     arguments: {
                         B: {
@@ -1520,7 +1520,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'touching',
-                    text: 'objet détecté [S]',
+                    text: messages.blocks.touching,
                     blockType: BlockType.HAT,
                     arguments: {
                         S: {
@@ -1532,7 +1532,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'notouching',
-                    text: 'pas d\'objet[S]',
+                    text: messages.blocks.notouching,
                     blockType: BlockType.HAT,
                     arguments: {
                         S: {
@@ -1544,7 +1544,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'touchingThreshold',
-                    text: 'objet détecté [S] [N]',
+                    text: messages.blocks.touchingThreshold,
                     blockType: BlockType.HAT,
                     arguments: {
                         S: {
@@ -1561,17 +1561,17 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'bump',
-                    text: 'choc',
+                    text: messages.blocks.bump,
                     blockType: BlockType.HAT
                 },
                 {
                     opcode: 'soundDetected',
-                    text: 'bruit détecté',
+                    text: messages.blocks.soundDetected,
                     blockType: BlockType.HAT
                 },
                 {
                     opcode: 'valButton',
-                    text: 'bouton [B]',
+                    text: messages.blocks.valButton,
                     blockType: BlockType.BOOLEAN,
                     arguments: {
                         B: {
@@ -1583,7 +1583,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'proximity',
-                    text: 'capteur horizontal [N]',
+                    text: messages.blocks.proximity,
                     blockType: BlockType.REPORTER,
                     arguments: {
                         N: {
@@ -1594,12 +1594,12 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'proxHorizontal',
-                    text: 'capteurs horizontaux',
+                    text: messages.blocks.proxHorizontal,
                     blockType: BlockType.REPORTER
                 },
                 {
                     opcode: 'ground',
-                    text: 'capteur dessous  [N]',
+                    text: messages.blocks.ground,
                     blockType: BlockType.REPORTER,
                     arguments: {
                         N: {
@@ -1610,12 +1610,12 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'proxGroundDelta',
-                    text: 'ground sensors',
+                    text: messages.blocks.proxGroundDelta,
                     blockType: BlockType.REPORTER
                 },
                 {
                     opcode: 'distance',
-                    text: 'distance [S]',
+                    text: messages.blocks.distance,
                     blockType: BlockType.REPORTER,
                     arguments: {
                         S: {
@@ -1627,7 +1627,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'angle',
-                    text: 'angle [S]',
+                    text: messages.blocks.angle,
                     blockType: BlockType.REPORTER,
                     arguments: {
                         S: {
@@ -1640,7 +1640,7 @@ class Scratch3ThymioBlocks {
 
                 {
                     opcode: 'tilt',
-                    text: 'inclinaison [T]',
+                    text: messages.blocks.tilt,
                     blockType: BlockType.REPORTER,
                     arguments: {
                         T: {
@@ -1652,12 +1652,12 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'micIntensity',
-                    text: 'niveau sonore',
+                    text: messages.blocks.micIntensity,
                     blockType: BlockType.REPORTER
                 },
                 {
                     opcode: 'odometer',
-                    text: 'odomètre [O]',
+                    text: messages.blocks.odometer,
                     blockType: BlockType.REPORTER,
                     arguments: {
                         O: {
@@ -1669,7 +1669,7 @@ class Scratch3ThymioBlocks {
                 },
                 {
                     opcode: 'motor',
-                    text: 'mesure vit. moteur [M]',
+                    text: messages.blocks.motor,
                     blockType: BlockType.REPORTER,
                     arguments: {
                         M: {
@@ -1698,68 +1698,68 @@ class Scratch3ThymioBlocks {
             ],
             menus: {
                 leftrightall: [
-                    {text: 'left', value: 'left'},
-                    {text: 'right', value: 'right'},
-                    {text: 'all', value: 'all'}
+                    {text: messages.menus.leftrightall.left, value: 'left'},
+                    {text: messages.menus.leftrightall.right, value: 'right'},
+                    {text: messages.menus.leftrightall.all, value: 'all'}
                 ],
                 leftright: [
-                    {text: 'left', value: 'left'},
-                    {text: 'right', value: 'right'}
+                    {text: messages.menus.leftright.left, value: 'left'},
+                    {text: messages.menus.leftright.right, value: 'right'}
                 ],
                 sensors: [
-                    {text: 'front', value: 'front'},
-                    {text: 'back', value: 'back'},
-                    {text: 'ground', value: 'ground'}
+                    {text: messages.menus.sensors.front, value: 'front'},
+                    {text: messages.menus.sensors.back, value: 'back'},
+                    {text: messages.menus.sensors.ground, value: 'ground'}
                 ],
                 sensors2: [
-                    {text: 'left', value: 'left'},
-                    {text: 'front', value: 'front'},
-                    {text: 'right', value: 'right'},
-                    {text: 'back', value: 'back'},
-                    {text: 'ground', value: 'ground'}
+                    {text: messages.menus.sensors2.left, value: 'left'},
+                    {text: messages.menus.sensors2.front, value: 'front'},
+                    {text: messages.menus.sensors2.right, value: 'right'},
+                    {text: messages.menus.sensors2.back, value: 'back'},
+                    {text: messages.menus.sensors2.ground, value: 'ground'}
                 ],
                 proxsensors: [
-                    {text: 'devant extrême gauche', value: 0},
-                    {text: 'devant gauche', value: 1},
-                    {text: 'devant centre', value: 2},
-                    {text: 'devant droite', value: 3},
-                    {text: 'devant extrême droite', value: 4},
-                    {text: 'derrière gauche', value: 5},
-                    {text: 'derrière droite', value: 6}
+                    {text: messages.menus.proxsensors.front_far_left, value: 0},
+                    {text: messages.menus.proxsensors.front_left, value: 1},
+                    {text: messages.menus.proxsensors.front_center, value: 2},
+                    {text: messages.menus.proxsensors.front_right, value: 3},
+                    {text: messages.menus.proxsensors.front_far_right, value: 4},
+                    {text: messages.menus.proxsensors.back_left, value: 5},
+                    {text: messages.menus.proxsensors.back_right, value: 6}
                 ],
                 light: [
-                    {text: 'all', value: 'all'},
-                    {text: 'top', value: 'top'},
-                    {text: 'bottom', value: 'bottom'},
-                    {text: 'bottom-left', value: 'bottom-left'},
-                    {text: 'bottom-right', value: 'bottom-right'}
+                    {text: messages.menus.light.all, value: 'all'},
+                    {text: messages.menus.light.top, value: 'top'},
+                    {text: messages.menus.light.bottom, value: 'bottom'},
+                    {text: messages.menus.light.bottom_left, value: 'bottom-left'},
+                    {text: messages.menus.light.bottom_right, value: 'bottom-right'}
                 ],
                 angles: [
-                    {text: 'front', value: 'front'},
-                    {text: 'back', value: 'back'},
-                    {text: 'ground', value: 'ground'}
+                    {text: messages.menus.angles.front, value: 'front'},
+                    {text: messages.menus.angles.back, value: 'back'},
+                    {text: messages.menus.angles.ground, value: 'ground'}
                 ],
                 sounds: ['0', '1', '2', '3', '4', '5', '6', '7'],
                 odo: [
-                    {text: 'direction', value: 'direction'},
-                    {text: 'x', value: 'x'},
-                    {text: 'y', value: 'y'}
+                    {text: messages.menus.odo.direction, value: 'direction'},
+                    {text: messages.menus.odo.x, value: 'x'},
+                    {text: messages.menus.odo.y, value: 'y'}
                 ],
                 tilts: [
-                    {text: 'front-back', value: 'front-back'},
-                    {text: 'top-bottom', value: 'top-bottom'},
-                    {text: 'left-right', value: 'left-right'}
+                    {text: messages.menus.tilts.front_back, value: 'front-back'},
+                    {text: messages.menus.tilts.top_bottom, value: 'top-bottom'},
+                    {text: messages.menus.tilts.left_right, value: 'left-right'}
                 ],
                 buttons: [
-                    {text: 'center', value: 'center'},
-                    {text: 'front', value: 'front'},
-                    {text: 'back', value: 'back'},
-                    {text: 'left', value: 'left'},
-                    {text: 'right', value: 'right'}
+                    {text: messages.menus.buttons.center, value: 'center'},
+                    {text: messages.menus.buttons.front, value: 'front'},
+                    {text: messages.menus.buttons.back, value: 'back'},
+                    {text: messages.menus.buttons.left, value: 'left'},
+                    {text: messages.menus.buttons.right, value: 'right'}
                 ],
                 nearfar: [
-                    {text: 'near', value: 'near'},
-                    {text: 'far', value: 'far'}
+                    {text: messages.menus.nearfar.near, value: 'near'},
+                    {text: messages.menus.nearfar.far, value: 'far'}
                 ]
             }
         };

--- a/src/extensions/scratch3_thymio/index.js
+++ b/src/extensions/scratch3_thymio/index.js
@@ -168,12 +168,12 @@ class Thymio {
         const url = `${Thymio.ASEBA_HTTP_URL}/nodes/thymio-II/${action}/${params}`;
 
         if (typeof callback === 'function') {
-            xmlhttp.onreadystatechange  = () => {
-				if (xmlhttp.readyState !== 4) {
-					return;
-				}
-			callback(xmlhttp);
-			};
+            xmlhttp.onreadystatechange = () => {
+                if (xmlhttp.readyState !== 4) {
+                    return;
+                }
+                callback(xmlhttp);
+            };
         }
 
         xmlhttp.open('GET', url, true);
@@ -551,7 +551,7 @@ class Thymio {
         }
         return false;
     }
-	notouching (sensor) {
+    notouching (sensor) {
         if (sensor === 'front') {
             let value = 0;
             for (let i = 0; i < 5; i++) {
@@ -576,38 +576,37 @@ class Thymio {
     }
     touchingThreshold (sensor, threshold) {
         let limit = 0;
-		if (threshold === 'far')
-			limit=1000;
-		else
-			limit=3000;
-		if (sensor === 'front') {
-                if (parseInt(this.cachedValues[19], 10) > limit) {
-                    return true;
-                }
-			return false;	
+        if (threshold === 'far') {
+            limit = 1000;
+        } else {
+            limit = 3000;
+        }
+        if (sensor === 'front') {
+            if (parseInt(this.cachedValues[19], 10) > limit) {
+                return true;
             }
-		else if (sensor === 'left') {
-			if (parseInt(this.cachedValues[17], 10) > limit || parseInt(this.cachedValues[18], 10) > limit) {
-                    return true;
-				}
-				return false;			
-		}
-		else if (sensor === 'right') {
+            return false;
+        } else if (sensor === 'left') {
+            if (parseInt(this.cachedValues[17], 10) > limit || parseInt(this.cachedValues[18], 10) > limit) {
+                return true;
+            }
+            return false;
+        } else if (sensor === 'right') {
             if (parseInt(this.cachedValues[20], 10) > limit || parseInt(this.cachedValues[21], 10) > limit) {
                 return true;
-			}
-			return false;			
-		}
-		else if (sensor === 'back') {
+            }
+            return false;
+        } else if (sensor === 'back') {
             if (parseInt(this.cachedValues[22], 10) > limit || parseInt(this.cachedValues[23], 10) > limit) {
                 return true;
             }
             return false;
         }
-		if (threshold === 'far')
-			limit=50;
-		else
-			limit=600;
+        if (threshold === 'far') {
+            limit = 50;
+        } else {
+            limit = 600;
+        }
         if (parseInt(this.cachedValues[15], 10) > limit || parseInt(this.cachedValues[16], 10) > limit) {
             return true;
         }
@@ -996,7 +995,7 @@ class Thymio {
             return false;
         }
     }
-	valButton (button) {
+    valButton (button) {
         const num = parseInt(this.cachedValues[2], 10);
 
         if (button === 'center') {
@@ -1162,7 +1161,7 @@ class Scratch3ThymioBlocks {
                         }
                     }
                 },
-				{
+                {
                     opcode: 'arc',
                     text: 'cercle rayon [R] angle [A]',
                     blockType: BlockType.COMMAND,
@@ -1177,7 +1176,7 @@ class Scratch3ThymioBlocks {
                         }
                     }
                 },
-				{
+                {
                     opcode: 'setOdomoter',
                     text: 'odomètre [N] [O] [P]',
                     blockType: BlockType.COMMAND,
@@ -1196,7 +1195,7 @@ class Scratch3ThymioBlocks {
                         }
                     }
                 },
-				{
+                {
                     opcode: 'leds',
                     text: 'leds RVB [L] [R] [G] [B]',
                     blockType: BlockType.COMMAND,
@@ -1256,8 +1255,8 @@ class Scratch3ThymioBlocks {
                     opcode: 'clearLeds',
                     text: 'éteindre leds',
                     blockType: BlockType.COMMAND
-                },               
-				{
+                },
+                {
                     opcode: 'nextDial',
                     text: 'led cadran suivante [L]',
                     blockType: BlockType.COMMAND,
@@ -1422,7 +1421,7 @@ class Scratch3ThymioBlocks {
                         }
                     }
                 },
-				{
+                {
                     opcode: 'soundSystem',
                     text: 'jouer son système [S]',
                     blockType: BlockType.COMMAND,
@@ -1482,7 +1481,7 @@ class Scratch3ThymioBlocks {
                         }
                     }
                 },
-				{
+                {
                     opcode: 'whenButton',
                     text: 'bouton [B]',
                     blockType: BlockType.HAT,
@@ -1494,7 +1493,7 @@ class Scratch3ThymioBlocks {
                         }
                     }
                 },
-				{
+                {
                     opcode: 'touching',
                     text: 'objet détecté [S]',
                     blockType: BlockType.HAT,
@@ -1506,7 +1505,7 @@ class Scratch3ThymioBlocks {
                         }
                     }
                 },
-				{
+                {
                     opcode: 'notouching',
                     text: 'pas d\'objet[S]',
                     blockType: BlockType.HAT,
@@ -1530,22 +1529,22 @@ class Scratch3ThymioBlocks {
                         },
                         N: {
                             type: ArgumentType.STRING,
-							menu: 'nearfar',
-							defaultValue: 'near'
+                            menu: 'nearfar',
+                            defaultValue: 'near'
                         }
                     }
                 },
-				{
+                {
                     opcode: 'bump',
                     text: 'choc',
                     blockType: BlockType.HAT
                 },
-				{
+                {
                     opcode: 'soundDetected',
                     text: 'bruit détecté',
                     blockType: BlockType.HAT
                 },
-				{
+                {
                     opcode: 'valButton',
                     text: 'bouton [B]',
                     blockType: BlockType.BOOLEAN,
@@ -1556,8 +1555,8 @@ class Scratch3ThymioBlocks {
                             defaultValue: 'center'
                         }
                     }
-                },				
-				{
+                },
+                {
                     opcode: 'proximity',
                     text: 'capteur horizontal [N]',
                     blockType: BlockType.REPORTER,
@@ -1568,7 +1567,7 @@ class Scratch3ThymioBlocks {
                         }
                     }
                 },
-				{
+                {
                     opcode: 'proxHorizontal',
                     text: 'capteurs horizontaux',
                     blockType: BlockType.REPORTER
@@ -1584,10 +1583,10 @@ class Scratch3ThymioBlocks {
                         }
                     }
                 },
-				{
+                {
                     opcode: 'proxGroundDelta',
-                    text: 'capteurs dessous',
-                    blockType: BlockType.REPORTER 
+                    text: 'ground sensors',
+                    blockType: BlockType.REPORTER
                 },
                 {
                     opcode: 'distance',
@@ -1613,7 +1612,7 @@ class Scratch3ThymioBlocks {
                         }
                     }
                 },
-                
+
                 {
                     opcode: 'tilt',
                     text: 'inclinaison [T]',
@@ -1625,12 +1624,12 @@ class Scratch3ThymioBlocks {
                             defaultValue: 'front-back'
                         }
                     }
-                },  
+                },
                 {
                     opcode: 'micIntensity',
                     text: 'niveau sonore',
                     blockType: BlockType.REPORTER
-                },              
+                },
                 {
                     opcode: 'odometer',
                     text: 'odomètre [O]',
@@ -1654,8 +1653,8 @@ class Scratch3ThymioBlocks {
                             defaultValue: 'left'
                         }
                     }
-                }                
-                /*{
+                }
+                /* {
                     opcode: 'emit',
                     text: 'emit [N]',
                     blockType: BlockType.COMMAND,
@@ -1670,30 +1669,30 @@ class Scratch3ThymioBlocks {
                     opcode: 'receive',
                     text: 'receive',
                     blockType: BlockType.REPORTER
-                },*/				
+                },*/
             ],
             menus: {
                 leftrightall: [
-					{text:'gauche', value: 'left'},
-					{text:'droite', value: 'right'},
-					{text:'tous', value: 'all'}
-				],
+                    {text: 'left', value: 'left'},
+                    {text: 'right', value: 'right'},
+                    {text: 'all', value: 'all'}
+                ],
                 leftright: [
-					{text:'gauche', value: 'left'},
-					{text:'droite', value: 'right'}
-				],
+                    {text: 'left', value: 'left'},
+                    {text: 'right', value: 'right'}
+                ],
                 sensors: [
-					{text:'devant', value: 'front'},
-					{text:'derrière', value: 'back'},
-					{text:'dessous', value: 'ground'}
-				],
-				sensors2: [
-					{text:'gauche', value: 'left'},
-					{text:'devant', value: 'front'},
-					{text:'droite', value: 'right'},
-					{text:'derrière', value: 'back'},
-					{text:'dessous', value: 'ground'}
-				],
+                    {text: 'front', value: 'front'},
+                    {text: 'back', value: 'back'},
+                    {text: 'ground', value: 'ground'}
+                ],
+                sensors2: [
+                    {text: 'left', value: 'left'},
+                    {text: 'front', value: 'front'},
+                    {text: 'right', value: 'right'},
+                    {text: 'back', value: 'back'},
+                    {text: 'ground', value: 'ground'}
+                ],
                 proxsensors: [
                     {text: 'devant extrême gauche', value: 0},
                     {text: 'devant gauche', value: 1},
@@ -1704,39 +1703,39 @@ class Scratch3ThymioBlocks {
                     {text: 'derrière droite', value: 6}
                 ],
                 light: [
-					{text:'tout', value: 'all'},
-					{text:'dessus', value: 'top'},
-					{text:'dessous', value: 'bottom'},
-					{text:'dessous-gauche', value: 'bottom-left'},
-					{text:'dessous-droite', value: 'bottom-right'}
-				],
+                    {text: 'all', value: 'all'},
+                    {text: 'top', value: 'top'},
+                    {text: 'bottom', value: 'bottom'},
+                    {text: 'bottom-left', value: 'bottom-left'},
+                    {text: 'bottom-right', value: 'bottom-right'}
+                ],
                 angles: [
-					{text:'devant', value: 'front'},
-					{text:'derrière', value: 'back'},
-					{text:'dessous', value: 'ground'}
-				],
+                    {text: 'front', value: 'front'},
+                    {text: 'back', value: 'back'},
+                    {text: 'ground', value: 'ground'}
+                ],
                 sounds: ['0', '1', '2', '3', '4', '5', '6', '7'],
                 odo: [
-					{text:'direction', value: 'direction'},
-					{text:'x', value: 'x'},
-					{text:'y', value: 'y'}
-				],
+                    {text: 'direction', value: 'direction'},
+                    {text: 'x', value: 'x'},
+                    {text: 'y', value: 'y'}
+                ],
                 tilts: [
-					{text:'devant-derrière', value: 'front-back'},
-					{text:'dessus-dessous', value: 'top-bottom'},
-					{text:'gauche-droite à plat', value: 'left-right'}
-				],
+                    {text: 'front-back', value: 'front-back'},
+                    {text: 'top-bottom', value: 'top-bottom'},
+                    {text: 'left-right', value: 'left-right'}
+                ],
                 buttons: [
-					{text:'centrale', value: 'center'},
-					{text:'devant', value: 'front'},
-					{text:'derrière', value: 'back'},
-					{text:'gauche', value: 'left'},
-					{text:'droite', value: 'right'}
-				],
-				nearfar: [
-					{text:'proche', value: 'near'},
-					{text:'loin', value: 'far'}
-				]
+                    {text: 'center', value: 'center'},
+                    {text: 'front', value: 'front'},
+                    {text: 'back', value: 'back'},
+                    {text: 'left', value: 'left'},
+                    {text: 'right', value: 'right'}
+                ],
+                nearfar: [
+                    {text: 'near', value: 'near'},
+                    {text: 'far', value: 'far'}
+                ]
             }
         };
     }
@@ -1898,7 +1897,7 @@ class Scratch3ThymioBlocks {
     touching (args) {
         return this.thymio.touching(args.S);
     }
-	notouching (args) {
+    notouching (args) {
         return this.thymio.notouching(args.S);
     }
     touchingThreshold (args) {
@@ -2040,7 +2039,7 @@ class Scratch3ThymioBlocks {
     whenButton (args) {
         return this.thymio.whenButton(args.B);
     }
-	valButton (args) {
+    valButton (args) {
         return this.thymio.valButton(args.B);
     }
 }

--- a/src/extensions/scratch3_thymio/index.js
+++ b/src/extensions/scratch3_thymio/index.js
@@ -21,6 +21,7 @@ const BlockType = require('../../extension-support/block-type');
 const Timer = require('../../util/timer');
 const Cast = require('../../util/cast');
 const log = require('../../util/log');
+const formatMessage = require('format-message');
 
 const aeslString = require('./aesl');
 const blockIconURI = require('./icon');
@@ -1036,6 +1037,10 @@ class Thymio {
  * Scratch 3.0 blocks to interact with a Thymio-II robot.
  */
 class Scratch3ThymioBlocks {
+    static get DEFAULT_LANG () {
+        return 'en';
+    }
+
     /**
      * Construct a set of Thymio blocks.
      * @param {Runtime} runtime - the Scratch 3.0 runtime.
@@ -1050,9 +1055,29 @@ class Scratch3ThymioBlocks {
         this.thymio = new Thymio();
     }
     /**
+      * @returns {object} messages - extension messages for locale
+        It is defined by using the current browser locale or the default (en) if the language is not (yet) supported.
+    */
+    getMessagesForLocale () {
+        const locale = formatMessage.setup().locale;
+
+        let messages;
+        try {
+            messages = require(`./lang/${locale}`);
+        } catch (ex) {
+            log.warn(`Locale "${locale}" is not (yet) supported for this extension.`);
+            log.warn(`Falling back to ${Scratch3ThymioBlocks.DEFAULT_LANG}`);
+
+            messages = require(`./lang/${Scratch3ThymioBlocks.DEFAULT_LANG}`);
+        }
+        return messages;
+    }
+    /**
      * @returns {object} metadata for this extension and its blocks.
      */
     getInfo () {
+        const messages = this.getMessagesForLocale();
+
         return {
             id: 'thymio',
             name: 'Thymio',

--- a/src/extensions/scratch3_thymio/lang/en.js
+++ b/src/extensions/scratch3_thymio/lang/en.js
@@ -1,0 +1,113 @@
+module.exports = {
+    blocks: {
+        setMotor: 'motor [M] [N]',
+        stopMotors: 'stop motors',
+        move: 'move [N]',
+        moveWithSpeed: 'move [N] with speed [S]',
+        moveWithTime: 'move [N] in [S]s',
+        turn: 'turn [N]',
+        turnWithSpeed: 'turn [N] with speed [S]',
+        turnWithTime: 'turn [N] in [S]s',
+        arc: 'circle radius [R] angle [A]',
+        setOdomoter: 'set odometer [N] [O] [P]',
+        leds: 'leds RGB [L] [R] [G] [B]',
+        setLeds: 'leds set color [C] on [L]',
+        changeLeds: 'leds change color [C] on [L]',
+        clearLeds: 'leds clear',
+        nextDial: 'leds next dial [L]',
+        ledsCircle: 'leds dial all [A] [B] [C] [D] [E] [F] [G] [H]',
+        ledsProxH: 'leds sensors h [A] [B] [C] [D] [E] [F] [G] [H]',
+        ledsProxV: 'leds sensors v [A] [B]',
+        ledsButtons: 'leds buttons [A] [B] [C] [D]',
+        ledsTemperature: 'leds temperature [A] [B]',
+        ledsRc: 'leds rc [A]',
+        ledsSound: 'leds sound [A]',
+        soundSystem: 'play system sound [S]',
+        soundFreq: 'play note [N] during [S]s',
+        soundPlaySd: 'play sound SD [N]',
+        soundRecord: 'record sound [N]',
+        soundReplay: 'replay sound [N]',
+        whenButton: 'when button [B]',
+        touching: 'object detected [S]',
+        notouching: 'no object [S]',
+        touchingThreshold: 'object detected [S] [N]',
+        bump: 'tap',
+        soundDetected: 'sound detected',
+        valButton: 'button [B]',
+        proximity: 'proximity sensor [N]',
+        proxHorizontal: 'proximity sensors',
+        ground: 'ground sensor [N]',
+        proxGroundDelta: 'ground sensors',
+        distance: 'distance [S]',
+        angle: 'angle [S]',
+        tilt: 'tilt on [T]',
+        micIntensity: 'sound level',
+        odometer: 'odometer [O]',
+        motor: 'measure motor [M]'
+    },
+    menus: {
+        leftrightall: {
+            left: 'left',
+            right: 'right',
+            all: 'all'
+        },
+        leftright: {
+            left: 'left',
+            right: 'right'
+        },
+        sensors: {
+            front: 'front',
+            back: 'back',
+            ground: 'ground'
+        },
+        sensors2: {
+            left: 'left',
+            front: 'front',
+            right: 'right',
+            back: 'back',
+            ground: 'ground'
+        },
+        proxsensors: {
+            front_far_left: 'front far left',
+            front_left: 'front left',
+            front_center: 'front center',
+            front_right: 'front right',
+            front_far_right: 'front far right',
+            back_left: 'back left',
+            back_right: 'back right'
+        },
+        light: {
+            all: 'all',
+            top: 'top',
+            bottom: 'bottom',
+            bottom_left: 'bottom left',
+            bottom_right: 'bottom right'
+        },
+        angles: {
+            front: 'front',
+            back: 'back',
+            ground: 'ground'
+        },
+        odo: {
+            direction: 'direction',
+            x: 'x',
+            y: 'y'
+        },
+        tilts: {
+            front_back: 'front-back',
+            top_bottom: 'top-bottom',
+            left_right: 'left-right'
+        },
+        buttons: {
+            center: 'center',
+            front: 'front',
+            back: 'back',
+            left: 'left',
+            right: 'right'
+        },
+        nearfar: {
+            near: 'near',
+            far: 'far'
+        }
+    }
+};

--- a/src/extensions/scratch3_thymio/lang/fr.js
+++ b/src/extensions/scratch3_thymio/lang/fr.js
@@ -1,0 +1,113 @@
+module.exports = {
+    blocks: {
+        setMotor: 'moteur [M] [N]',
+        stopMotors: 'stop moteurs',
+        move: 'avancer [N]',
+        moveWithSpeed: 'avancer [N] avec vitesse [S]',
+        moveWithTime: 'avancer [N] en [S]s',
+        turn: 'tourner [N]',
+        turnWithSpeed: 'tourner [N] avec vitesse [S]',
+        turnWithTime: 'tourner [N] en [S]s',
+        arc: 'cercle rayon [R] angle [A]',
+        setOdomoter: 'odomètre [N] [O] [P]',
+        leds: 'leds RVB [L] [R] [G] [B]',
+        setLeds: 'leds fixer couleur [C] pour [L]',
+        changeLeds: 'leds changer couleur [C] pour [L]',
+        clearLeds: 'éteindre leds',
+        nextDial: 'led cadran suivante [L]',
+        ledsCircle: 'leds cadran toutes [A] [B] [C] [D] [E] [F] [G] [H]',
+        ledsProxH: 'leds capteurs horiz. [A] [B] [C] [D] [E] [F] [G] [H]',
+        ledsProxV: 'leds capteurs dessous [A] [B]',
+        ledsButtons: 'leds boutons [A] [B] [C] [D]',
+        ledsTemperature: 'leds température [A] [B]',
+        ledsRc: 'leds rc [A]',
+        ledsSound: 'leds son [A]',
+        soundSystem: 'jouer son système [S]',
+        soundFreq: 'jouer note [N] pendant [S]s',
+        soundPlaySd: 'jouer son SD [N]',
+        soundRecord: 'enregistrer son [N]',
+        soundReplay: 'rejouer son [N]',
+        whenButton: 'bouton [B]',
+        touching: 'objet détecté [S]',
+        notouching: 'pas d\'objet [S]',
+        touchingThreshold: 'objet détecté [S] [N]',
+        bump: 'choc',
+        soundDetected: 'bruit',
+        valButton: 'bouton [B]',
+        proximity: 'capteur horizontal [N]',
+        proxHorizontal: 'capteurs horizontaux',
+        ground: 'capteur dessous [N]',
+        proxGroundDelta: 'capteurs dessous',
+        distance: 'distance [S]',
+        angle: 'angle [S]',
+        tilt: 'inclinaison [T]',
+        micIntensity: 'niveau sonore',
+        odometer: 'odomètre [O]',
+        motor: 'mesure moteur [M]'
+    },
+    menus: {
+        leftrightall: {
+            left: 'gauche',
+            right: 'droite',
+            all: 'tous'
+        },
+        leftright: {
+            left: 'gauche',
+            right: 'droite'
+        },
+        sensors: {
+            front: 'devant',
+            back: 'derrière',
+            ground: 'dessous'
+        },
+        sensors2: {
+            left: 'gauche',
+            front: 'devant',
+            right: 'droite',
+            back: 'derrière',
+            ground: 'dessous'
+        },
+        proxsensors: {
+            front_far_left: 'devant extrême gauche',
+            front_left: 'devabt gauche',
+            front_center: 'devant centre',
+            front_right: 'devant droite',
+            front_far_right: 'devant extrême droite',
+            back_left: 'derrière gauche',
+            back_right: 'derrière droite'
+        },
+        light: {
+            all: 'tout',
+            top: 'dessus',
+            bottom: 'dessous',
+            bottom_left: 'dessous gauche',
+            bottom_right: 'dessous droite'
+        },
+        angles: {
+            front: 'devant',
+            back: 'derrière',
+            ground: 'dessous'
+        },
+        odo: {
+            direction: 'direction',
+            x: 'x',
+            y: 'y'
+        },
+        tilts: {
+            front_back: 'devant-derrière',
+            top_bottom: 'dessus-dessous',
+            left_right: 'gauche-droite à plat'
+        },
+        buttons: {
+            center: 'central',
+            front: 'devant',
+            back: 'derrière',
+            left: 'gauche',
+            right: 'droite'
+        },
+        nearfar: {
+            near: 'proche',
+            far: 'loin'
+        }
+    }
+};

--- a/src/extensions/scratch3_thymio/lang/it.js
+++ b/src/extensions/scratch3_thymio/lang/it.js
@@ -1,0 +1,113 @@
+module.exports = {
+    blocks: {
+        setMotor: 'motori [M] [N]',
+        stopMotors: 'ferma motori',
+        move: 'avanza di [N]',
+        moveWithSpeed: 'avanza di [N] con velocità [S]',
+        moveWithTime: 'avanza di [N] in [S]s',
+        turn: 'rutoa di [N] gradi',
+        turnWithSpeed: 'ruota di [N] grandi con velocità [S]',
+        turnWithTime: 'ruota di [N] in [S]s',
+        arc: 'fai un cerchio di raggio [R] per [A] gradi',
+        setOdomoter: 'inizializza isometria [N] [O] [P]',
+        leds: 'tutti i LED RVB [L] [R] [G] [B]',
+        setLeds: 'colora LED [C] [L]',
+        changeLeds: 'cambia colore LED [C] [L]',
+        clearLeds: 'spegni LED',
+        nextDial: 'on LED quadrante [L]',
+        ledsCircle: 'on LED quadrante [A] [B] [C] [D] [E] [F] [G] [H]',
+        ledsProxH: 'LED sensori prox. [A] [B] [C] [D] [E] [F] [G] [H]',
+        ledsProxV: 'LED sensori terreno [A] [B]',
+        ledsButtons: 'LED bottoni [A] [B] [C] [D]',
+        ledsTemperature: 'LED bottoni [A] [B]',
+        ledsRc: 'LED RC [A]',
+        ledsSound: 'LED microfono [A]',
+        soundSystem: 'suona suono Thymio [S]',
+        soundFreq: 'suona nota [N] per [S]s',
+        soundPlaySd: 'suono suono su scheda SD [N]',
+        soundRecord: 'registra suono [N]',
+        soundReplay: 'riproduci suono [N]',
+        whenButton: 'bottone [B]',
+        touching: 'oggetto rilevato [S]',
+        notouching: 'nessun oggetto rilevato [S]', // TODO: correct?
+        touchingThreshold: 'oggetto rilevato [S] [N]',
+        bump: 'urto',
+        soundDetected: 'rumore captato',
+        valButton: 'bottone [B]',
+        proximity: 'sensore prox. [N]',
+        proxHorizontal: 'sensori di prox.',
+        ground: 'sensore terreno [N]',
+        proxGroundDelta: 'sensori di prox.',
+        distance: 'distanza [S]',
+        angle: 'angolo [S]',
+        tilt: 'inclinazione [T]',
+        micIntensity: 'livello sonoro',
+        odometer: 'isometria [O]',
+        motor: 'misura motori [M]'
+    },
+    menus: {
+        leftrightall: {
+            left: 'sinistro',
+            right: 'destro',
+            all: 'tutti'
+        },
+        leftright: {
+            left: 'sinistro',
+            right: 'destro'
+        },
+        sensors: {
+            front: 'devanti',
+            back: 'dietro',
+            ground: 'terreno'
+        },
+        sensors2: {
+            left: 'sinistro',
+            front: 'devanti',
+            right: 'destro',
+            back: 'dietro',
+            ground: 'terreno'
+        },
+        proxsensors: {
+            front_far_left: 'tutto a sinistra',
+            front_left: 'a sinistra',
+            front_center: 'centrale',
+            front_right: 'a destra',
+            front_far_right: 'tutto a destra',
+            back_left: 'posteriore sinistro',
+            back_right: 'posteriore destro'
+        },
+        light: {
+            all: 'tutti',
+            top: 'superiori',
+            bottom: 'inferiori',
+            bottom_left: 'inferiori a sinistra',
+            bottom_right: 'inferiori a destra'
+        },
+        angles: {
+            front: 'devanti',
+            back: 'dietro',
+            ground: 'terreno'
+        },
+        odo: {
+            direction: 'direzione',
+            x: 'x',
+            y: 'y'
+        },
+        tilts: {
+            front_back: 'devanti-dietro',
+            top_bottom: 'sopra-sotto',
+            left_right: 'sinistro-destro'
+        },
+        buttons: {
+            center: 'centrale',
+            front: 'devanti',
+            back: 'dietro',
+            left: 'sinistro',
+            right: 'destra'
+        },
+        nearfar: {
+            near: 'vicina', // TODO: correct?
+            far: 'lontana' // TODO: correct?
+        }
+    }
+};


### PR DESCRIPTION
This PR proposes:

* a custom mechanism to allow translation for the Thymio extension without the need to fork scratch-l10n
* translation for a specific language is given in an independent file
* when a translation does not exist for a language, the default texts (English) are used
* adding a new supported language does not require to modify the extension code itself (see below for details)

This mechanism will most likely become obsolete when the official way of translating extension will be described by the LLK team. This custom approach also does not permit the translation of the extension description in the extension selection menu.

### Supporting a new language

To add support for another language, you first need to create a file for the target locale. The file should be name with the locale identification and placed in the *src/extensions/scratch3_thymio/lang* folder. For instance, to add support for German, you need no create the file  *src/extensions/scratch3_thymio/lang/de.js*.

To pre-fill this file, the easiest way is to actually copy the content from another translation (for example from the  *src/extensions/scratch3_thymio/lang/en.js* file). 

Then, you simply need to translate all English string texts to their corresponding German line. For instance, the line ```stopMotors: 'stop motors',``` becomes ```stopMotors: 'motoren anhalten',``` (according to google translate translation).

Finally, rebuild the project. This new language should automatically be used when switching Scratch to German.
